### PR TITLE
Skip items that don't exist in the current client

### DIFF
--- a/BetterBags_WarWithin.toc
+++ b/BetterBags_WarWithin.toc
@@ -1,4 +1,4 @@
-## Interface: 110207, 120000
+## Interface: 120000, 120001
 
 ## Title: BetterBags - The War Within
 ## Notes: Filter for common War Within items in BetterBags.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Bump TOC to 12.0.1
 
+### Fixed
+- Remove deleted items
+
 ## [1.12.0] 2026-01-22
 ### Changed
 - Bump TOC to 12.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Changed
+- Bump TOC to 12.0.1
+
 ## [1.12.0] 2026-01-22
 ### Changed
 - Bump TOC to 12.0.0

--- a/db.lua
+++ b/db.lua
@@ -322,10 +322,10 @@ addon.db = {
 		221269, -- Crimson Valorstone
 		226813, -- Golden Valorstone
 		225896, -- Void-Touched Valorstone
-		-- Season 2
+		-- Season 2 | these items have been removed from the game
 		236953, -- Crimson Valorstone
-		232382, -- Golden Valorstone
-		236954, -- Void-Touched Valorstone
+		-- 232382, -- Golden Valorstone
+		-- 236954, -- Void-Touched Valorstone
 		-- Greyed out ones
 		236955, -- Crimson Valorstone
 		237036, -- Golden Valorstone

--- a/main.lua
+++ b/main.lua
@@ -22,8 +22,9 @@ local ctx = context:New('BBTWW_Event')
 for category, items in pairs(addon.db) do
 	categories:WipeCategory(ctx, L:G(category))
 	for _, item in pairs(items) do
-		-- pcall to skip items that no longer exist in the current client
-		-- (e.g. seasonal items not yet active or removed between patches)
-		pcall(categories.AddItemToCategory, categories, ctx, item, L:G(category))
+		local success, err = pcall(categories.AddItemToCategory, categories, ctx, item, L:G(category))
+		--@debug@
+		if not success then print(err) end
+		--@end-debug@
 	end
 end

--- a/main.lua
+++ b/main.lua
@@ -22,6 +22,8 @@ local ctx = context:New('BBTWW_Event')
 for category, items in pairs(addon.db) do
 	categories:WipeCategory(ctx, L:G(category))
 	for _, item in pairs(items) do
-		categories:AddItemToCategory(ctx, item, L:G(category))
+		-- pcall to skip items that no longer exist in the current client
+		-- (e.g. seasonal items not yet active or removed between patches)
+		pcall(categories.AddItemToCategory, categories, ctx, item, L:G(category))
 	end
 end


### PR DESCRIPTION
## Summary

- `AddItemToCategory` in BetterBags core asserts that `C_Item.GetItemInfoInstant(id)` returns a value
- This crashes when an item ID is not yet active or was removed between patches
- Currently item 236953 (Crimson Valorstone, Season 2) throws on every login/reload:
  ```
  BetterBags/data/categories.lua:164: Attempted to add item 236953 to category |cffff8040Valorstones|r, but the item does not exist.
  ```
- Fix: wrap `AddItemToCategory` in `pcall` so unavailable items are silently skipped

This is a more robust approach than removing individual item IDs, since any item could become stale/unavailable between patches.

## Test plan

- [ ] Login/reload with the fix — no more assertion error for item 236953
- [ ] Items that do exist are still correctly categorized in BetterBags

🤖 Generated with [Claude Code](https://claude.com/claude-code)